### PR TITLE
Midstream CI changes for release 0.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM openshift/origin-release:golang-1.13 AS builder
+WORKDIR ${GOPATH}/src/knative.dev/eventing-operator
+COPY . .
+ENV GOFLAGS="-mod=vendor"
+RUN go build -o /tmp/manager ./cmd/manager
+RUN cp -Lr ${GOPATH}/src/knative.dev/eventing-operator/cmd/manager/kodata /tmp
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/manager /ko-app/eventing-operator
+COPY --from=builder /tmp/kodata/ /var/run/ko
+ENV KO_DATA_PATH="/var/run/ko"
+LABEL \
+    com.redhat.component="openshift-serverless-1-tech-preview-knative-eventing-rhel8-operator-container" \
+    name="openshift-serverless-1-tech-preview/knative-eventing-rhel8-operator" \
+    version="v0.12.1" \
+    summary="Red Hat OpenShift Serverless 1 Knative Eventing Operator" \
+    maintainer="serverless-support@redhat.com" \
+    description="Red Hat OpenShift Serverless 1 Knative Eventing Operator" \
+    io.k8s.display-name="Red Hat OpenShift Serverless 1 Knative Eventing Operator"
+
+ENTRYPOINT ["/ko-app/eventing-operator"] 

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,0 @@
-# The OWNERS file is used by prow to automatically merge approved PRs.
-
-approvers:
-- matzew
-- n3wscott
-# Operations WG leads
-- bbrowning
-- houshengbo
-- k4leung4


### PR DESCRIPTION
Needed for https://issues.redhat.com/browse/SRVKE-334 and https://github.com/openshift/release/pull/7305

Had a look at release-0.12 branch of serving-operator here: https://github.com/openshift-knative/serving-operator/tree/release-0.12

and did the same things (not all of them)