### PR TITLE
Midstream CI changes for release 0.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM rhel8/go-toolset:1.13.4 AS builder
+WORKDIR ${GOPATH}/src/knative.dev/eventing-operator
+COPY . .
+ENV GOFLAGS="-mod=vendor"
+RUN go build -o /tmp/manager ./cmd/manager
+RUN cp -Lr ${GOPATH}/src/knative.dev/eventing-operator/cmd/manager/kodata /tmp
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/manager /ko-app/eventing-operator
+COPY --from=builder /tmp/kodata/ /var/run/ko
+ENV KO_DATA_PATH="/var/run/ko"
+LABEL \
+    com.redhat.component="openshift-serverless-1-tech-preview-knative-eventing-rhel8-operator-container" \
+    name="openshift-serverless-1-tech-preview/knative-eventing-rhel8-operator" \
+    version="v0.13.0" \
+    summary="Red Hat OpenShift Serverless 1 Knative Eventing Operator" \
+    maintainer="serverless-support@redhat.com" \
+    description="Red Hat OpenShift Serverless 1 Knative Eventing Operator" \
+    io.k8s.display-name="Red Hat OpenShift Serverless 1 Knative Eventing Operator"
+
+ENTRYPOINT ["/ko-app/eventing-operator"] 

--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,0 @@
-# The OWNERS file is used by prow to automatically merge approved PRs.
-
-approvers:
-- matzew
-- n3wscott
-# Operations WG leads
-- houshengbo
-- k4leung4


### PR DESCRIPTION
Same as https://github.com/openshift-knative/eventing-operator/pull/2

Procedure:
1. Push upstream 0.13 branch to this repo as is
2. Delete OWNERS, create Dockerfile
3. Push to own repo, create a PR against the *release-0.13* branch