### PR TITLE
Openshift knative release 0.13 fix image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rhel8/go-toolset:1.13.4 AS builder
+FROM openshift/origin-release:golang-1.13 AS builder
 WORKDIR ${GOPATH}/src/knative.dev/eventing-operator
 COPY . .
 ENV GOFLAGS="-mod=vendor"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM rhel8/go-toolset:1.13.4 AS builder
+WORKDIR ${GOPATH}/src/knative.dev/eventing-operator
+COPY . .
+ENV GOFLAGS="-mod=vendor"
+RUN go build -o /tmp/manager ./cmd/manager
+RUN cp -Lr ${GOPATH}/src/knative.dev/eventing-operator/cmd/manager/kodata /tmp
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/manager /ko-app/eventing-operator
+COPY --from=builder /tmp/kodata/ /var/run/ko
+ENV KO_DATA_PATH="/var/run/ko"
+LABEL \
+    com.redhat.component="openshift-serverless-1-tech-preview-knative-eventing-rhel8-operator-container" \
+    name="openshift-serverless-1-tech-preview/knative-eventing-rhel8-operator" \
+    version="v0.13.0" \
+    summary="Red Hat OpenShift Serverless 1 Knative Eventing Operator" \
+    maintainer="serverless-support@redhat.com" \
+    description="Red Hat OpenShift Serverless 1 Knative Eventing Operator" \
+    io.k8s.display-name="Red Hat OpenShift Serverless 1 Knative Eventing Operator"
+
+ENTRYPOINT ["/ko-app/eventing-operator"] 

--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,0 @@
-# The OWNERS file is used by prow to automatically merge approved PRs.
-
-approvers:
-- matzew
-- n3wscott
-# Operations WG leads
-- houshengbo
-- k4leung4


### PR DESCRIPTION
Image used in Dockerfile during https://github.com/openshift-knative/eventing-operator/pull/3 fails in https://github.com/openshift/release/pull/7812

```
docke...hel8/go-toolset not found: does not exist or no pull access
```

Using the image we previously used now.