### PR TITLE
SRVKE-351 increase eventing-webhook memory limit

### DIFF
--- a/cmd/manager/kodata/knative-eventing/0.13.3.yaml
+++ b/cmd/manager/kodata/knative-eventing/0.13.3.yaml
@@ -350,7 +350,7 @@ spec:
             memory: 20Mi
           limits:
             cpu: 200m
-            memory: 200Mi
+            memory: 1024Mi
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/SRVKE-351, same of https://github.com/openshift-knative/serving-operator/pull/7