### PR TITLE
SRVKE-388, port to own own 0.13 version

### DIFF
--- a/cmd/manager/kodata/knative-eventing/0.13.3.yaml
+++ b/cmd/manager/kodata/knative-eventing/0.13.3.yaml
@@ -1653,7 +1653,7 @@ spec:
     JSONPath: .spec.broker
   - name: Subscriber_URI
     type: string
-    JSONPath: .status.subscriberURI
+    JSONPath: .status.subscriberUri
   - name: Age
     type: date
     JSONPath: .metadata.creationTimestamp


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

See: https://issues.redhat.com/browse/SRVKE-388

this is the backport to 0.13 (1.7.0)

/assign @maschmid 
/assign @aliok 