### PR TITLE
Remove resources, like done on upstream

### DIFF
--- a/cmd/manager/kodata/knative-eventing/0.13.3.yaml
+++ b/cmd/manager/kodata/knative-eventing/0.13.3.yaml
@@ -3042,11 +3042,4 @@ spec:
         ports:
         - containerPort: 9090
           name: metrics
-        resources:
-          requests:
-            cpu: 1000m
-            memory: 256Mi
-          limits:
-            cpu: 2200m
-            memory: 2048Mi
 ---


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

see: https://issues.redhat.com/browse/SRVKE-403

removing the resources for the `imc-dispatcher`. Potential fix for a 1.7.z stream release.

Upstream has _this_ fix already on 0.14.z and HEAD (0.15)