### PR TITLE
use proper container names...

### DIFF
--- a/cmd/manager/kodata/knative-eventing/1-eventing.yaml
+++ b/cmd/manager/kodata/knative-eventing/1-eventing.yaml
@@ -2961,7 +2961,7 @@ spec:
     spec:
       serviceAccountName: eventing-controller
       containers:
-      - name: eventing-controller
+      - name: broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
         image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-channel-broker
         resources:
@@ -3689,7 +3689,7 @@ spec:
     spec:
       serviceAccountName: eventing-controller
       containers:
-      - name: eventing-controller
+      - name: mt-broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
         image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-mtchannel-broker
         resources:
@@ -4838,7 +4838,7 @@ spec:
     spec:
       serviceAccountName: imc-controller
       containers:
-      - name: controller
+      - name: imc-controller
         image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-channel-controller
         env:
         - name: CONFIG_LOGGING_NAME

--- a/cmd/manager/kodata/knative-eventing/1-eventing.yaml
+++ b/cmd/manager/kodata/knative-eventing/1-eventing.yaml
@@ -4895,7 +4895,7 @@ spec:
     spec:
       serviceAccountName: imc-dispatcher
       containers:
-      - name: dispatcher
+      - name: imc-dispatcher
         image: registry.svc.ci.openshift.org/openshift/knative-v0.14.0:knative-eventing-channel-dispatcher
         env:
         - name: CONFIG_LOGGING_NAME


### PR DESCRIPTION
With out this change there are a few `controller` and `eventing-controller` containers...

so the deployment gets confused 


part of that has been fixed in upstream:
https://github.com/knative/eventing/commit/40f0a540923eb858985e7c1df309e9d898dbbed1

/assign @aliok 